### PR TITLE
Movie & Podcast

### DIFF
--- a/classes/Movie.js
+++ b/classes/Movie.js
@@ -1,6 +1,27 @@
 // import the Media class:
+const Media = require("./Media");
 
 // create your Movie class:
+class Movie extends Media {
+    constructor(title, year, genre, director, duration, rating) {
+        super(title, year, genre);
+        this.director = director;
+        this.duration = duration;
+        this.rating = rating;
+    }
+
+    summary() {
+        return `Title: ${this.title}, Director: ${this.director}, Year: ${this.year}, Genre: ${this.genre}, Duration: ${this.duration}, Rating: ${this.rating}`
+    }
+
+    static longestMovie(movies) {
+        const movieLengths = movies.map((movie) => {
+            return movie.duration;
+        })
+        const targetIndex = movieLengths.indexOf(Math.max(...movieLengths));
+        return movies[targetIndex];
+    }
+}
 
 // don't change below
 module.exports = Movie;

--- a/classes/Movie.test.js
+++ b/classes/Movie.test.js
@@ -39,7 +39,7 @@ describe('Movie tests', () => {
       4.5
     )
     expect(movie1.summary()).toBe(
-      'Title: Inception, Director: Christopher Nolan, Year: 2010, Genre: Sci-Fi, Rating: 4.5'
+      'Title: Inception, Director: Christopher Nolan, Year: 2010, Genre: Sci-Fi, Duration: 148, Rating: 4.5'
     )
   })
 

--- a/classes/Podcast.js
+++ b/classes/Podcast.js
@@ -1,0 +1,27 @@
+const Music = require("./Music");
+
+class Podcast extends Music {
+  constructor(
+    title,
+    year,
+    genre,
+    artist,
+    length,
+    host,
+    episodeName,
+    episodeNumber,
+    guests
+  ) {
+    super(title, year, genre, artist, length);
+    this.host = host;
+    this.episodeName = episodeName;
+    this.episodeNumber = episodeNumber;
+    this.guests = guests;
+  }
+
+  listen() {
+    return `${this.title} - Episode: ${this.episodeName}. Hosted by ${this.host} and featuring guests ${this.guests}. Length: ${this.length} seconds.`;
+  }
+}
+
+module.exports = Podcast;

--- a/classes/Podcast.test.js
+++ b/classes/Podcast.test.js
@@ -1,24 +1,38 @@
 const Music = require("./Music");
 const Podcast = require("./Podcast");
-const { describe, test, expect, beforeEach } = require("@jest/globals"); 
+const { describe, test, expect, beforeEach } = require("@jest/globals");
 
-describe('Podcast tests' , () => {
-    beforeEach(() => {
-        const testPodcast = new Podcast("The Basement Yard", 2015, "Comedy", "Basement Boys", 361, "Joe & Frank", "Frank's Big Fight", 72, "N/A");
-    })
+describe("Podcast tests", () => {
+  let testPodcast;
+  beforeEach(() => {
+    testPodcast = new Podcast(
+      "The Basement Yard",
+      2015,
+      "Comedy",
+      "Basement Boys",
+      361,
+      "Joe & Frank",
+      "Frank's Big Fight",
+      72,
+      "N/A"
+    );
+  });
 
-    test('Can create a new Podcast instance that is child of Music', () => {
-        expect(testPodcast).toBeInstanceOf(Music);
-    })
+  test("Can create a new Podcast instance that is child of Music", () => {
+    expect(testPodcast).toBeInstanceOf(Podcast);
+    expect(testPodcast).toBeInstanceOf(Music);
+  });
 
-    test('Podcast has properties of host, episodeName, episodeNumber, and guests', () => {
-        expect(testPodcast).toHaveProperty("host", "Joe & Frank");
-        expect(testPodcast).toHaveProperty("episodeName", "Frank's Big Fight");
-        expect(testPodcast).toHaveProperty("episodeNumber", 72);
-        expect(testPodcast).toHaveProperty("guests", "N/A");
-    })
+  test("Podcast has properties of host, episodeName, episodeNumber, and guests", () => {
+    expect(testPodcast).toHaveProperty("host", "Joe & Frank");
+    expect(testPodcast).toHaveProperty("episodeName", "Frank's Big Fight");
+    expect(testPodcast).toHaveProperty("episodeNumber", 72);
+    expect(testPodcast).toHaveProperty("guests", "N/A");
+  });
 
-    test('Podcast summary method returns the correct summary', () => {
-        expect(testPodcast.listen()).toBe("The Basement Yard - Episode: Frank's Big Fight. Hosted by Basement Boys and featuring guests N/A. Length: 361 seconds.");
-    })
-})
+  test("Podcast summary method returns the correct summary", () => {
+    expect(testPodcast.listen()).toBe(
+      "The Basement Yard - Episode: Frank's Big Fight. Hosted by Joe & Frank and featuring guests N/A. Length: 361 seconds."
+    );
+  });
+});

--- a/classes/Podcast.test.js
+++ b/classes/Podcast.test.js
@@ -1,0 +1,24 @@
+const Music = require("./Music");
+const Podcast = require("./Podcast");
+const { describe, test, expect, beforeEach } = require("@jest/globals"); 
+
+describe('Podcast tests' , () => {
+    beforeEach(() => {
+        const testPodcast = new Podcast("The Basement Yard", 2015, "Comedy", "Basement Boys", 361, "Joe & Frank", "Frank's Big Fight", 72, "N/A");
+    })
+
+    test('Can create a new Podcast instance that is child of Music', () => {
+        expect(testPodcast).toBeInstanceOf(Music);
+    })
+
+    test('Podcast has properties of host, episodeName, episodeNumber, and guests', () => {
+        expect(testPodcast).toHaveProperty("host", "Joe & Frank");
+        expect(testPodcast).toHaveProperty("episodeName", "Frank's Big Fight");
+        expect(testPodcast).toHaveProperty("episodeNumber", 72);
+        expect(testPodcast).toHaveProperty("guests", "N/A");
+    })
+
+    test('Podcast summary method returns the correct summary', () => {
+        expect(testPodcast.listen()).toBe("The Basement Yard - Episode: Frank's Big Fight. Hosted by Basement Boys and featuring guests N/A. Length: 361 seconds.");
+    })
+})


### PR DESCRIPTION
## Summary
- This update completes the Movie and Podcast(extension) classes

## Changes
- Movie class extends Media
  - Properties:
    - title, year, genre(inherited from Media class)
    - director, duration, rating
  - Methods: 
    - summary()
    - longestMovie() (static)
- Podcast class
  - Properties:
    - title, year, genre, artist, length (inherited from Music and Media)
    - host, episodeName, episodeNumber, guests 
  - Methods:  
    - listen() 
- Podcast tests
  - coverage for properties and listen() method

## Related Issues
- N/A
